### PR TITLE
Fix tag is needed when pushing to registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
             ghcr.io/kafji/wmd
           tags: |
             type=edge
-            type=sha,prefix=rev-
             type=ref,event=branch
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{version}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
 
       - uses: docker/setup-buildx-action@v1
 
-      - uses: docker/metadata-action@v3
+      - id: image-metadata
+        uses: docker/metadata-action@v3
         with:
           images: |
             ghcr.io/kafji/wmd
@@ -58,8 +59,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.image-metadata.outputs.tags }}
+          labels: ${{ steps.image-metadata.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/kafji/wmd:buildcache
           cache-to: type=registry,ref=ghcr.io/kafji/wmd:buildcache,mode=max


### PR DESCRIPTION
Accessing output from previous steps require the step to have an id.